### PR TITLE
Add krkn-hub reference in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# kraken-hub
+# krkn-hub aka kraken-hub
 
 Hosts container images and wrapper for running scenarios supported by [Kraken](https://github.com/cloud-bulldozer/kraken), a chaos testing tool for OpenShift/Kubernetes clusters to ensure it is resilient to failures. All we need to do is run the containers with the respective environment variables defined as supported by the scenarios without having to maintain and tweak files!
 


### PR DESCRIPTION
### Description
Kraken is now krkn - https://github.com/cloud-bulldozer/krkn. This change
helps align with the renaming.




